### PR TITLE
Fix #1: Bug: divide_numbers crashes when divisor is zero

### DIFF
--- a/app/calculator.py
+++ b/app/calculator.py
@@ -14,7 +14,9 @@ def multiply(a, b):
 
 
 def divide_numbers(a, b):
-    """Divide a by b and return the result."""
+    """Divide a by b and return the result. Raises ValueError on division by zero."""
+    if b == 0:
+        raise ValueError("Cannot divide by zero")
     return a / b
 
 


### PR DESCRIPTION
**Problem:**
The `divide_numbers` function in `app/calculator.py` did not handle division by zero and would raise an unhandled `ZeroDivisionError` if called with a divisor of zero.

**Fix:**
- Updated `divide_numbers` to check if the divisor (`b`) is zero and raise a `ValueError` with the message "Cannot divide by zero" if so, as expected.

This prevents the unhandled exception and provides a clear, user-friendly error message.

Fixes #1.