### PR TITLE
Fix #1: Bug: divide_numbers crashes when divisor is zero

### DIFF
--- a/app/calculator.py
+++ b/app/calculator.py
@@ -14,7 +14,9 @@ def multiply(a, b):
 
 
 def divide_numbers(a, b):
-    """Divide a by b and return the result."""
+    """Divide a by b and return the result. Raises ValueError on division by zero."""
+    if b == 0:
+        raise ValueError("Cannot divide by zero")
     return a / b
 
 


### PR DESCRIPTION
This PR fixes issue #1.

**Problem:**
The `divide_numbers` function in `app/calculator.py` raised an unhandled `ZeroDivisionError` when the divisor was zero.

**Solution:**
The function now raises a `ValueError` with the message "Cannot divide by zero" if the divisor is zero, as expected.

Fixes #1.