### PR TITLE
Fix #6: Bug: find_word is case-sensitive but should not be

### DIFF
--- a/app/string_utils.py
+++ b/app/string_utils.py
@@ -11,7 +11,7 @@ def count_vowels(s):
 
 def find_word(text, word):
     """Check if word exists in text. Returns True/False."""
-    return word in text
+    return word.lower() in text.lower()
 
 
 def capitalize_words(s):


### PR DESCRIPTION
This PR fixes issue #6.

**Problem:**
The `find_word` function in `app/string_utils.py` was performing a case-sensitive search, causing `find_word("hello world", "World")` to return `False` instead of `True`.

**Solution:**
Both `text` and `word` are now converted to lowercase before performing the search, making the function case-insensitive.

Fixes #6.